### PR TITLE
fix: fixes typo repalce -> replace

### DIFF
--- a/lib/stdio/file.sh
+++ b/lib/stdio/file.sh
@@ -567,7 +567,7 @@ p6_file_marker_delete_to_end() {
     local file="$1"
     local marker="$2"
 
-    p6_file_repalce "$file" "/^$marker/,\$d"
+    p6_file_replace "$file" "/^$marker/,\$d"
 
     p6_return_void
 }


### PR DESCRIPTION
# p6_git_util_msg_collect(): lines below this marker will be ignored
M  lib/stdio/file.sh
diff --git c/lib/stdio/file.sh w/lib/stdio/file.sh
index 68dd985..f44417a 100644
--- c/lib/stdio/file.sh
+++ w/lib/stdio/file.sh
@@ -567,7 +567,7 @@ p6_file_marker_delete_to_end() {
     local file="$1"
     local marker="$2"

-    p6_file_repalce "$file" "/^$marker/,\$d"
+    p6_file_replace "$file" "/^$marker/,\$d"

     p6_return_void
 }
